### PR TITLE
Groestlcoin (GRS) xpub support

### DIFF
--- a/hdkeychain/bench_test.go
+++ b/hdkeychain/bench_test.go
@@ -7,6 +7,7 @@ package hdkeychain_test
 import (
 	"testing"
 
+	"github.com/martinboehm/btcutil/base58"
 	"github.com/martinboehm/btcutil/hdkeychain"
 )
 
@@ -19,7 +20,7 @@ const bip0032MasterPriv1 = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbP" +
 // child from a master private extended key.
 func BenchmarkDeriveHardened(b *testing.B) {
 	b.StopTimer()
-	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1)
+	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1, base58.Sha256D)
 	if err != nil {
 		b.Errorf("Failed to decode master seed: %v", err)
 	}
@@ -34,7 +35,7 @@ func BenchmarkDeriveHardened(b *testing.B) {
 // (non-hardened) child from a master private extended key.
 func BenchmarkDeriveNormal(b *testing.B) {
 	b.StopTimer()
-	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1)
+	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1, base58.Sha256D)
 	if err != nil {
 		b.Errorf("Failed to decode master seed: %v", err)
 	}
@@ -49,7 +50,7 @@ func BenchmarkDeriveNormal(b *testing.B) {
 // key to a public extended key.
 func BenchmarkPrivToPub(b *testing.B) {
 	b.StopTimer()
-	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1)
+	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1, base58.Sha256D)
 	if err != nil {
 		b.Errorf("Failed to decode master seed: %v", err)
 	}
@@ -64,7 +65,7 @@ func BenchmarkPrivToPub(b *testing.B) {
 // extended key.
 func BenchmarkDeserialize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		hdkeychain.NewKeyFromString(bip0032MasterPriv1)
+		hdkeychain.NewKeyFromString(bip0032MasterPriv1, base58.Sha256D)
 	}
 }
 
@@ -72,7 +73,7 @@ func BenchmarkDeserialize(b *testing.B) {
 // extended key.
 func BenchmarkSerialize(b *testing.B) {
 	b.StopTimer()
-	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1)
+	masterKey, err := hdkeychain.NewKeyFromString(bip0032MasterPriv1, base58.Sha256D)
 	if err != nil {
 		b.Errorf("Failed to decode master seed: %v", err)
 	}

--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -7,6 +7,7 @@ package hdkeychain_test
 import (
 	"fmt"
 
+	"github.com/martinboehm/btcutil/base58"
 	"github.com/martinboehm/btcutil/chaincfg"
 	"github.com/martinboehm/btcutil/hdkeychain"
 )
@@ -63,7 +64,7 @@ func Example_defaultWalletLayout() {
 	// Start by getting an extended key instance for the master node.
 	// This gives the path:
 	//   m
-	masterKey, err := hdkeychain.NewKeyFromString(master)
+	masterKey, err := hdkeychain.NewKeyFromString(master, base58.Sha256D)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -162,7 +163,7 @@ func Example_audits() {
 	// Start by getting an extended key instance for the master node.
 	// This gives the path:
 	//   m
-	masterKey, err := hdkeychain.NewKeyFromString(master)
+	masterKey, err := hdkeychain.NewKeyFromString(master, base58.Sha256D)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -105,14 +105,15 @@ var masterKey = []byte("Bitcoin seed")
 // deterministic extended key.  See the package overview documentation for
 // more details on how to use extended keys.
 type ExtendedKey struct {
-	key       []byte // This will be the pubkey for extended pub keys
-	pubKey    []byte // This will only be set for extended priv keys
-	chainCode []byte
-	depth     uint8
-	parentFP  []byte
-	childNum  uint32
-	version   []byte
-	isPrivate bool
+	key         []byte // This will be the pubkey for extended pub keys
+	pubKey      []byte // This will only be set for extended priv keys
+	chainCode   []byte
+	depth       uint8
+	parentFP    []byte
+	childNum    uint32
+	version     []byte
+	isPrivate   bool
+	cksumHasher base58.CksumHasher
 }
 
 // NewExtendedKey returns a new instance of an extended key with the given
@@ -121,18 +122,19 @@ type ExtendedKey struct {
 // only by used by applications that need to create custom ExtendedKeys. All
 // other applications should just use NewMaster, Child, or Neuter.
 func NewExtendedKey(version, key, chainCode, parentFP []byte, depth uint8,
-	childNum uint32, isPrivate bool) *ExtendedKey {
+	childNum uint32, isPrivate bool, cksumHasher base58.CksumHasher) *ExtendedKey {
 
 	// NOTE: The pubKey field is intentionally left nil so it is only
 	// computed and memoized as required.
 	return &ExtendedKey{
-		key:       key,
-		chainCode: chainCode,
-		depth:     depth,
-		parentFP:  parentFP,
-		childNum:  childNum,
-		version:   version,
-		isPrivate: isPrivate,
+		key:         key,
+		chainCode:   chainCode,
+		depth:       depth,
+		parentFP:    parentFP,
+		childNum:    childNum,
+		version:     version,
+		isPrivate:   isPrivate,
+		cksumHasher: cksumHasher,
 	}
 }
 
@@ -325,7 +327,7 @@ func (k *ExtendedKey) Child(i uint32) (*ExtendedKey, error) {
 	// bytes of the RIPEMD160(SHA256(parentPubKey)).
 	parentFP := btcutil.Hash160(k.pubKeyBytes())[:4]
 	return NewExtendedKey(k.version, childKey, childChainCode, parentFP,
-		k.depth+1, i, isPrivate), nil
+		k.depth+1, i, isPrivate, k.cksumHasher), nil
 }
 
 // Neuter returns a new extended public key from this extended private key.  The
@@ -353,7 +355,7 @@ func (k *ExtendedKey) Neuter() (*ExtendedKey, error) {
 	//
 	// This is the function N((k,c)) -> (K, c) from [BIP32].
 	return NewExtendedKey(version, k.pubKeyBytes(), k.chainCode, k.parentFP,
-		k.depth, k.childNum, false), nil
+		k.depth, k.childNum, false, k.cksumHasher), nil
 }
 
 // ECPubKey converts the extended key to a btcec public key and returns it.
@@ -415,7 +417,7 @@ func (k *ExtendedKey) String() string {
 	} else {
 		serializedBytes = append(serializedBytes, k.pubKeyBytes()...)
 	}
-	return base58.CheckEncode(serializedBytes, k.version, base58.Sha256D)
+	return base58.CheckEncode(serializedBytes, k.version, k.cksumHasher)
 }
 
 // IsForNet returns whether or not the extended key is associated with the
@@ -494,16 +496,16 @@ func NewMaster(seed []byte, net *chaincfg.Params) (*ExtendedKey, error) {
 
 	parentFP := []byte{0x00, 0x00, 0x00, 0x00}
 	return NewExtendedKey(net.HDPrivateKeyID[:], secretKey, chainCode,
-		parentFP, 0, 0, true), nil
+		parentFP, 0, 0, true, net.Base58CksumHasher), nil
 }
 
 // NewKeyFromString returns a new extended key instance from a base58-encoded
 // extended key.
-func NewKeyFromString(key string) (*ExtendedKey, error) {
+func NewKeyFromString(key string, cksumHasher base58.CksumHasher) (*ExtendedKey, error) {
 	// The base58-decoded extended key must consist of a serialized payload
 	// plus an additional 4 bytes for the checksum. We use 0 as version length
 	// because we want it to be part of the payload.
-	payload, _, err := base58.CheckDecode(key, 0, base58.Sha256D)
+	payload, _, err := base58.CheckDecode(key, 0, cksumHasher)
 	if err != nil {
 		return nil, ErrBadChecksum
 	}
@@ -544,7 +546,7 @@ func NewKeyFromString(key string) (*ExtendedKey, error) {
 	}
 
 	return NewExtendedKey(version, keyData, chainCode, parentFP, depth,
-		childNum, isPrivate), nil
+		childNum, isPrivate, cksumHasher), nil
 }
 
 // GenerateSeed returns a cryptographically secure random seed that can be used

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -408,12 +408,15 @@ func TestPublicDerivation(t *testing.T) {
 	// The public extended keys for test vectors in [BIP32].
 	testVec1MasterPubKey := "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
 	testVec2MasterPubKey := "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+	// Groestlcoin test
+	testVec3MasterPubKey := "xpub661MyMwAqRbcFLgDU7wpcEVubSF7NkswwmXBUkDiGUW6uopeUMys4AqKXNgpfZKRTLnpKQgffd6a2c3J8JxLkF1AQN17Pm9QYHEqEdHH2EN"
 
 	tests := []struct {
 		name    string
 		master  string
 		path    []uint32
 		wantPub string
+		hasher  base58.CksumHasher
 	}{
 		// Test vector 1
 		{
@@ -421,36 +424,42 @@ func TestPublicDerivation(t *testing.T) {
 			master:  testVec1MasterPubKey,
 			path:    []uint32{},
 			wantPub: "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 1 chain m/0",
 			master:  testVec1MasterPubKey,
 			path:    []uint32{0},
 			wantPub: "xpub68Gmy5EVb2BdFbj2LpWrk1M7obNuaPTpT5oh9QCCo5sRfqSHVYWex97WpDZzszdzHzxXDAzPLVSwybe4uPYkSk4G3gnrPqqkV9RyNzAcNJ1",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 1 chain m/0/1",
 			master:  testVec1MasterPubKey,
 			path:    []uint32{0, 1},
 			wantPub: "xpub6AvUGrnEpfvJBbfx7sQ89Q8hEMPM65UteqEX4yUbUiES2jHfjexmfJoxCGSwFMZiPBaKQT1RiKWrKfuDV4vpgVs4Xn8PpPTR2i79rwHd4Zr",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 1 chain m/0/1/2",
 			master:  testVec1MasterPubKey,
 			path:    []uint32{0, 1, 2},
 			wantPub: "xpub6BqyndF6rhZqmgktFCBcapkwubGxPqoAZtQaYewJHXVKZcLdnqBVC8N6f6FSHWUghjuTLeubWyQWfJdk2G3tGgvgj3qngo4vLTnnSjAZckv",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 1 chain m/0/1/2/2",
 			master:  testVec1MasterPubKey,
 			path:    []uint32{0, 1, 2, 2},
 			wantPub: "xpub6FHUhLbYYkgFQiFrDiXRfQFXBB2msCxKTsNyAExi6keFxQ8sHfwpogY3p3s1ePSpUqLNYks5T6a3JqpCGszt4kxbyq7tUoFP5c8KWyiDtPp",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 1 chain m/0/1/2/2/1000000000",
 			master:  testVec1MasterPubKey,
 			path:    []uint32{0, 1, 2, 2, 1000000000},
 			wantPub: "xpub6GX3zWVgSgPc5tgjE6ogT9nfwSADD3tdsxpzd7jJoJMqSY12Be6VQEFwDCp6wAQoZsH2iq5nNocHEaVDxBcobPrkZCjYW3QUmoDYzMFBDu9",
+			hasher:  base58.Sha256D,
 		},
 
 		// Test vector 2
@@ -459,42 +468,71 @@ func TestPublicDerivation(t *testing.T) {
 			master:  testVec2MasterPubKey,
 			path:    []uint32{},
 			wantPub: "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 2 chain m/0",
 			master:  testVec2MasterPubKey,
 			path:    []uint32{0},
 			wantPub: "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 2 chain m/0/2147483647",
 			master:  testVec2MasterPubKey,
 			path:    []uint32{0, 2147483647},
 			wantPub: "xpub6ASAVgeWMg4pmutghzHG3BohahjwNwPmy2DgM6W9wGegtPrvNgjBwuZRD7hSDFhYfunq8vDgwG4ah1gVzZysgp3UsKz7VNjCnSUJJ5T4fdD",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 2 chain m/0/2147483647/1",
 			master:  testVec2MasterPubKey,
 			path:    []uint32{0, 2147483647, 1},
 			wantPub: "xpub6CrnV7NzJy4VdgP5niTpqWJiFXMAca6qBm5Hfsry77SQmN1HGYHnjsZSujoHzdxf7ZNK5UVrmDXFPiEW2ecwHGWMFGUxPC9ARipss9rXd4b",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 2 chain m/0/2147483647/1/2147483646",
 			master:  testVec2MasterPubKey,
 			path:    []uint32{0, 2147483647, 1, 2147483646},
 			wantPub: "xpub6FL2423qFaWzHCvBndkN9cbkn5cysiUeFq4eb9t9kE88jcmY63tNuLNRzpHPdAM4dUpLhZ7aUm2cJ5zF7KYonf4jAPfRqTMTRBNkQL3Tfta",
+			hasher:  base58.Sha256D,
 		},
 		{
 			name:    "test vector 2 chain m/0/2147483647/1/2147483646/2",
 			master:  testVec2MasterPubKey,
 			path:    []uint32{0, 2147483647, 1, 2147483646, 2},
 			wantPub: "xpub6H7WkJf547AiSwAbX6xsm8Bmq9M9P1Gjequ5SipsjipWmtXSyp4C3uwzewedGEgAMsDy4jEvNTWtxLyqqHY9C12gaBmgUdk2CGmwachwnWK",
+			hasher:  base58.Sha256D,
+		},
+
+		// Test vector 3 (Groestlcoin)
+		{
+			name:    "test vector 3 chain m",
+			master:  testVec3MasterPubKey,
+			path:    []uint32{},
+			wantPub: testVec3MasterPubKey,
+			hasher:  base58.Groestl512D,
+		},
+		{
+			name:    "test vector 2 chain m/0",
+			master:  testVec3MasterPubKey,
+			path:    []uint32{0},
+			wantPub: "xpub68Zyu13hPwsx8egknnRtfGmk6n9f6S5zbousZUJmQDZsB3GCppTz73oD2WS8DcCa4hqvNePCt8dFt5TKSSBgvCdgg48iWZQ7qgKnFYssEMa",
+			hasher:  base58.Groestl512D,
+		},
+		{
+			name:    "test vector 2 chain m/0/2147483647",
+			master:  testVec3MasterPubKey,
+			path:    []uint32{0, 2147483647},
+			wantPub: "xpub6ALvHVtBofjyjcAG968U1Jpm1qoKVUoHZ6owPAKAVcMa8UmG48p8ThhmfLsdz94za8vrrgwriTRLweteZZcabxuh6vUgUssShwGa73uVYvG",
+			hasher:  base58.Groestl512D,
 		},
 	}
 
 tests:
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.master, base58.Sha256D)
+		extKey, err := NewKeyFromString(test.master, test.hasher)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected error "+
 				"creating extended key: %v", i, test.name,

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/martinboehm/btcutil/base58"
 	"github.com/martinboehm/btcutil/chaincfg"
 )
 
@@ -374,7 +375,7 @@ func TestPrivateDerivation(t *testing.T) {
 
 tests:
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.master)
+		extKey, err := NewKeyFromString(test.master, base58.Sha256D)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected error "+
 				"creating extended key: %v", i, test.name,
@@ -493,7 +494,7 @@ func TestPublicDerivation(t *testing.T) {
 
 tests:
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.master)
+		extKey, err := NewKeyFromString(test.master, base58.Sha256D)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected error "+
 				"creating extended key: %v", i, test.name,
@@ -591,7 +592,7 @@ func TestExtendedKeyAPI(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		key, err := NewKeyFromString(test.extKey)
+		key, err := NewKeyFromString(test.extKey, base58.Sha256D)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected "+
 				"error: %v", i, test.name, err)
@@ -754,7 +755,7 @@ func TestNet(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.key)
+		extKey, err := NewKeyFromString(test.key, base58.Sha256D)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected error "+
 				"creating extended key: %v", i, test.name,
@@ -878,7 +879,7 @@ func TestErrors(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.key)
+		extKey, err := NewKeyFromString(test.key, base58.Sha256D)
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("NewKeyFromString #%d (%s): mismatched error "+
 				"-- got: %v, want: %v", i, test.name, err,
@@ -1022,7 +1023,7 @@ func TestZero(t *testing.T) {
 		}
 
 		// Deserialize key and get the neutered version.
-		key, err = NewKeyFromString(test.extKey)
+		key, err = NewKeyFromString(test.extKey, base58.Sha256D)
 		if err != nil {
 			t.Errorf("NewKeyFromString #%d (%s): unexpected "+
 				"error: %v", i, test.name, err)

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -854,9 +854,9 @@ func TestErrors(t *testing.T) {
 		neuterErr error
 	}{
 		{
-			name: "invalid key length",
+			name: "invalid key length and bad checksum",
 			key:  "xpub1234",
-			err:  ErrInvalidKeyLen,
+			err:  ErrBadChecksum,
 		},
 		{
 			name: "bad checksum",


### PR DESCRIPTION
Blockbook recently introduced xpub support, however it works incorrectly for GRS, because GRS uses different hash for base58 checksum. This PR adds support for custom xpub checksum by reusing `base58.Check{En,De}code` instead of manual checksum verification. API changes are minimal and Blockbook needs only provide `chaincfg.Params.Base58CksumHasher` to `hdkeychain.NewKeyFromString()` calls.