### PR TITLE
Update Address decoding to fix Litecoin decode bug

### DIFF
--- a/address.go
+++ b/address.go
@@ -144,26 +144,28 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 		prefix := addr[:oneIndex+1]
 		if chaincfg.IsBech32SegwitPrefix(prefix) {
 			witnessVer, witnessProg, err := decodeSegWitAddress(addr)
-			if err != nil {
-				return nil, err
-			}
+			// Some non-segwit addresses (for example, Litecoin `L` addresses)
+			// may also start with the segwit prefix even though they are
+			// legacy addresses. In this case decodeSegWitAddress returns error
+			// and we proceed to try decoding as a legacy address below.
+			if err == nil {
+				// We currently only support P2WPKH and P2WSH, which is
+				// witness version 0.
+				if witnessVer != 0 {
+					return nil, UnsupportedWitnessVerError(witnessVer)
+				}
 
-			// We currently only support P2WPKH and P2WSH, which is
-			// witness version 0.
-			if witnessVer != 0 {
-				return nil, UnsupportedWitnessVerError(witnessVer)
-			}
+				// The HRP is everything before the found '1'.
+				hrp := prefix[:len(prefix)-1]
 
-			// The HRP is everything before the found '1'.
-			hrp := prefix[:len(prefix)-1]
-
-			switch len(witnessProg) {
-			case 20:
-				return newAddressWitnessPubKeyHash(hrp, witnessProg)
-			case 32:
-				return newAddressWitnessScriptHash(hrp, witnessProg)
-			default:
-				return nil, UnsupportedWitnessProgLenError(len(witnessProg))
+				switch len(witnessProg) {
+				case 20:
+					return newAddressWitnessPubKeyHash(hrp, witnessProg)
+				case 32:
+					return newAddressWitnessScriptHash(hrp, witnessProg)
+				default:
+					return nil, UnsupportedWitnessProgLenError(len(witnessProg))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Litecoin segwit addresses start with ltc1, however there is about a 1 in 40,000
chance that a legacy L address will also start with ltc1. When this happens the
address decoding fails as it make the decision to parse as segwit or parse as
legacy based on the prefix. In this case it tries and fails to parse as segwit
since the prefix is ltc.

This commit makes a small change to the parse logic to check both the prefix
and the encoding when deciding whether to parse as segwit or legacy.

Tests are updated to test for this case.